### PR TITLE
Backup improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Optional Variables:
 * `cert-manager-enabled` - Set to "1" to enable Cert Manager (0 by default)
 * `cert-manager-email` - The email address to use for Let's Encrypt certificate requests ("" by default)
 * `cluster-autoscaler-enabled` - Set to "1" to enable the cluster autoscaler (0 by default)
-* `k8stoken` - Override the automatically generated cluster bootstrap token
+* `k8stoken` - Override the automatically generated cluster bootstrap token. Can also be generated with `kubeadm token generate`.
 
 ### Examples
 * [Nginx deployment](examples/nginx.yaml)
@@ -66,4 +66,3 @@ I've written this as a personal project and will do my best to maintain it to a 
 ### Note about the license
 
 I am not associated with UPMC Enterprises, but because this project started off as a fork of their code I am required to leave their license in place. However this is still Open Source and so you are free to do more-or-less whatever you want with the contents of this repository.
-

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Optional Variables:
 * `cluster-name` - Used for naming the created AWS resources (k8s by default)
 * `backup-enabled` - Set to "0" to disable the automatic etcd backups (1 by default)
 * `backup-cron-expression` - A cron expression to use for the automatic etcd backups (`*/15 * * * *` by default)
+* `versioned-bucket` - Set to "false" to only keep the most recent etcd backup (true by default)
 * `external-dns-enabled` - Set to "0" to disable ExternalDNS (1 by default) - Existing Route 53 Domain required
 * `nginx-ingress-enabled` - Set to "1" to enable Nginx Ingress (0 by default)
 * `nginx-ingress-domain` - The DNS name to map to Nginx Ingress using External DNS ("" by default)

--- a/main.tf
+++ b/main.tf
@@ -166,18 +166,23 @@ resource "aws_s3_bucket" "s3-bucket" {
   bucket_prefix   = "${var.cluster-name}"
   force_destroy   = "true"
 
-  tags {
-    Environment = "${var.cluster-name}"
+  versioning {
+    enabled = "${var.versioned-bucket}"
   }
 
   lifecycle_rule {
-    id      = "etcd-backups"
-    prefix  = "etcd-backups/"
     enabled = true
+    id      = "bucket"
+    prefix  = ""
+    abort_incomplete_multipart_upload_days = 1
 
-    expiration {
+    noncurrent_version_expiration {
       days = 7
     }
+  }
+
+  tags {
+    Environment = "${var.cluster-name}"
   }
 }
 
@@ -523,4 +528,3 @@ resource "aws_autoscaling_group" "worker" {
     propagate_at_launch = true
   }
 }
-

--- a/master.sh
+++ b/master.sh
@@ -75,15 +75,14 @@ networking:
   podSubnet: 10.244.0.0/16
 EOF
 
-# Check if there is an etcd backup on the s3 bucket and restore from it if there is
-if [ $(aws s3 ls s3://${s3bucket}/etcd-backups/ | wc -l) -ne 0 ]; then
-  echo "Found existing etcd backup. Restoring from it instead of starting from fresh."
-  LATEST_BACKUP=$(aws s3api list-objects --no-paginate --bucket ${s3bucket} --prefix etcd-backups --query 'reverse(sort_by(Contents,&LastModified))[0].Key' --output text)
-  echo "Found etcd snapshot: $LATEST_BACKUP"
+echo "Checking s3://${s3bucket}/etcd-snapshot.db.xz"
+aws s3 cp s3://${s3bucket}/etcd-snapshot.db.xz etcd-snapshot.db.xz || echo "Snapshot not found."
+
+if [ -f etcd-snapshot.db.xz ]; then
+  echo "Found etcd snapshot"
+  unxz etcd-snapshot.db.xz
 
   echo "Restoring etcd snapshot"
-  aws s3 cp s3://${s3bucket}/$LATEST_BACKUP etcd-snapshot.db.xz
-  unxz etcd-snapshot.db.xz
   ETCDCTL_API=3 etcdctl snapshot restore etcd-snapshot.db --data-dir /var/lib/etcd
 
   echo "Downloading Kubernetes pki data"
@@ -139,12 +138,12 @@ fi
 # Set up backups if they have been enabled
 # This section is indented with tabs to make the EOF heredocs work
 if [[ "${backupenabled}" == "1" ]]; then
-	# Back up etcd to s3 every 15 minutes. The lifecycle policy in terraform will keep 7 days to save us doing that logic here.
+	# Back up etcd to s3 every 15 minutes. A lifecycle rule will delete previous versions after 7 days.
 	cat <<-EOF > /usr/local/bin/backup-etcd.sh
 	#!/bin/bash
 	ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert='/etc/kubernetes/pki/etcd/ca.crt' --cert='/etc/kubernetes/pki/etcd/peer.crt' --key='/etc/kubernetes/pki/etcd/peer.key' snapshot save etcd-snapshot.db
 	xz -f -9 etcd-snapshot.db
-	aws s3 cp --metadata instanceid=$INSTANCE_ID etcd-snapshot.db.xz s3://${s3bucket}/etcd-backups/etcd-snapshot-\$(date -Iseconds)-$INSTANCE_ID.db.xz
+	aws s3 cp --metadata instanceid=$INSTANCE_ID etcd-snapshot.db.xz s3://${s3bucket}/etcd-snapshot.db.xz
 	EOF
 
 	echo "${backupcron} root bash /usr/local/bin/backup-etcd.sh" > /etc/cron.d/backup-etcd

--- a/variables.tf
+++ b/variables.tf
@@ -111,6 +111,11 @@ variable "backup-enabled" {
   description = "Whether or not the automatic S3 backup should be enabled. (1 for enabled, 0 for disabled)"
 }
 
+variable "versioned-bucket" {
+  default = "true"
+  description = "Whether or not the S3 bucket should be versioned."
+}
+
 variable "backup-cron-expression" {
   default = "*/15 * * * *"
   description = "A cron expression to use for the automatic etcd backups."


### PR DESCRIPTION
Hi there. I have used parts of this project and modified it beyond recognition.

But I felt it necessary to contribute back some of my improvements. Mostly because of the pki issue I encountered and filed here: https://github.com/cablespaghetti/kubeadm-aws/issues/13

And also because the S3 storage costs can be lowered dramatically by compressing them first, and using versioning instead of timestamps in the filename to keep older backups. This way if the user wants to minimize costs, then versioning should be left disabled. There is no need to keep more than the latest etcd snapshot around. And no need to backup the pki data more than once.

And not to mention, the restoration code had a bug where an outdated snapshot would be restored if the backup interval was increased. That is a huge bug, although it won't be encountered by most people using this project. 1000 objects are returned by default from `aws s3api list-objects`, and about 700 objects would be created if when taking backups every 15 minutes and deleting them after 7 days. The most recent backup is at the very end of the list-objects API response, since it's always sorted alphabetically.

In my opinion, the `backup-enabled` variable should be removed, and then `versioned-bucket` can be used to save money. The cost of keeping a single backup around should be very low (especially now with compression). Self-healing should be a cornerstone of this project, and is impossible without a backup.

And please test these changes, since I copy-pasted them back from my changed version, and I haven't done a lot of testing on the backported version.

I have made some other improvements that you may want to incorporate, but I didn't include them in this PR:
- Add a DNS name to the CA cert to allow it to be called from a remote computer more easily. Can be accomplished with:
   ```
   kind: ClusterConfiguration
   apiVersion: kubeadm.k8s.io/v1beta1
   apiServer:
     certSANs:
     - "${kubernetes_hostname}"
   ```
- Use an EIP to have a consistent public IP to the master, and assign it to the master in the userdata script:
   ```
   aws ec2 associate-address --instance-id $INSTANCE_ID --allocation-id ${eip_id}
   ```
- Use S3 public access blocking to further secure the bucket, ensuring that public access is never accidentally granted to an object in it.
   ```
   resource "aws_s3_bucket_public_access_block" "s3-bucket" {
     bucket                  = "${aws_s3_bucket.s3-bucket.id}"
     block_public_acls       = true
     block_public_policy     = true
     ignore_public_acls      = true
     restrict_public_buckets = true
   }
   ```
- Use more than a single subnet in order to maximize the chance of getting spot instances with low price. Although this could have the undesired effect of causing more cross-AZ traffic, has incurs additional costs, if workers are being used. Maybe the README should encourage the user to do some spot price research so they understand how the pricing works. Although the default instance type should always be cheap. I am using a much more powerful instance type.
- This is overkill, but I am taking a daily snapshot as well, and archiving it straight to S3 Glacier Deep Archive, and keeping these snapshots for 180 days (minimum cost for Deep Archive). This way I can restore my cluster to any state in the past 180 days. This is mostly a fun experiment and it wouldn't be very useful for many, as restoring the backups out of Deep Archive takes a long time.